### PR TITLE
When support for Solr Cluster was added the touch points in collectio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+fusion-ext.iml
+fusion-ext.iws
+fusion-ext.ipr


### PR DESCRIPTION
…n creation routines which assumed all collections are local were not updated.

- only pop off the solrParams.name of local collections from *COL.json.  This causes the POST to create the collection if the collection does not exist and a fall-thru to PUT if it does.
- leave the solrParams.name for remote collections.  This causes the POST to fail if the remote collection does not exist